### PR TITLE
Use 'let' for local variable

### DIFF
--- a/app/public/spotifySampler.js
+++ b/app/public/spotifySampler.js
@@ -104,7 +104,7 @@
             console.log(response)
 
             // Add tracks to the set
-            for (item of response.items) {
+            for (let item of response.items) {
               storeSet.add(item.track.id)
             }
 


### PR DESCRIPTION
This PR fixes an LGTM warning by using the let keyword on a local variable